### PR TITLE
Changing db directory name.py

### DIFF
--- a/2024/gemma2_local_rag/ollama_gemma2_rag_debugging.py
+++ b/2024/gemma2_local_rag/ollama_gemma2_rag_debugging.py
@@ -12,7 +12,7 @@ from langchain.schema.output_parser import StrOutputParser
 # # Create embeddingsclear
 embeddings = OllamaEmbeddings(model="nomic-embed-text", show_progress=True)
 
-db = Chroma(persist_directory="./db",
+db = Chroma(persist_directory="./db-hormozi",
             embedding_function=embeddings)
 
 # # Create retriever


### PR DESCRIPTION
In the "indexer.py" file, the `persist_directory` is set to "./db-hormozi," while in "ollama_gemma2_rag_debugging.py," it is set to "./db."